### PR TITLE
[fix] 질의응답 상세페이지 목데이터로 변경 (#37)

### DIFF
--- a/src/components/common/ProfileImage.tsx
+++ b/src/components/common/ProfileImage.tsx
@@ -1,7 +1,7 @@
 import ProfileThumb from '@/assets/images/svg/ProfileThumb.svg?react'
 
 interface ProfileImageProps {
-  imageUrl?: string
+  imageUrl?: string | null | undefined
   alt?: string
   size?: number
 }

--- a/src/components/common/ThumbnailImage.tsx
+++ b/src/components/common/ThumbnailImage.tsx
@@ -1,7 +1,7 @@
 import imgListThumb from '@/assets/images/imgListThumb.png'
 
 interface ThumbnailImageProps {
-  imageUrl?: string
+  imageUrl?: string | null | undefined
   alt?: string
   className?: string
 }

--- a/src/components/details/DetailsAnswerItem.tsx
+++ b/src/components/details/DetailsAnswerItem.tsx
@@ -1,9 +1,11 @@
 import ProfileImage from '@/assets/images/svg/ProfileThumb.svg'
-import Button from '@/components/common/Button'
 import TextArea from '@/components/common/TextArea'
 import DetailsComment from '@/components/details/DetailsComment'
-
-export default function DetailsAnswerItem() {
+import type { QnaAnswer } from '@/types'
+interface Props {
+  answer: QnaAnswer
+}
+export default function DetailsAnswerItem({ answer }: Props) {
   return (
     <div className="answer_box">
       {/* 답변 헤더 */}
@@ -11,7 +13,7 @@ export default function DetailsAnswerItem() {
         <div className="flex-center gap-[12px]">
           <img src={ProfileImage} alt="프로필 이미지" />
           <div>
-            <span className="answer_name">{'랑이'}</span>
+            <span className="answer_name">{answer.author.nickname}</span>
             <p className="answer_info">
               <span>
                 IT스타트업 실무형 풀스택 웹 개발 부트캠프 (React + Node.js) &lt;
@@ -39,7 +41,7 @@ export default function DetailsAnswerItem() {
       <TextArea />
 
       {/* 댓글 영역 */}
-      <DetailsComment />
+      <DetailsComment comments={answer.comments} />
     </div>
   )
 }

--- a/src/components/details/DetailsAnswerList.tsx
+++ b/src/components/details/DetailsAnswerList.tsx
@@ -1,7 +1,9 @@
 import DetailsAnswerItem from '@/components/details/DetailsAnswerItem'
-export default function DetailsAnswerList() {
-  // 임시
-  const answers = [{ id: 1 }, { id: 2 }]
+import type { QnaAnswer } from '@/types'
+interface DetailsAnswerListProps {
+  answers: QnaAnswer[]
+}
+export default function DetailsAnswerList({ answers }: DetailsAnswerListProps) {
   return (
     <section className="answer_area mt-[52px]">
       <h3 className="answer_title">
@@ -11,7 +13,7 @@ export default function DetailsAnswerList() {
 
       <div className="flex flex-col gap-[24px]">
         {answers.map((answer) => (
-          <DetailsAnswerItem key={answer.id} />
+          <DetailsAnswerItem key={answer.id} answer={answer} />
         ))}
       </div>
     </section>

--- a/src/components/details/DetailsComment.tsx
+++ b/src/components/details/DetailsComment.tsx
@@ -2,12 +2,14 @@ import SortIcon from '@/assets/images/svg/Sorting.svg?react'
 import CommentIcon from '@/assets/images/svg/Comment.svg?react'
 import DetailsCommentItem from '@/components/details/DetailsCommentItem'
 import { useState } from 'react'
-
-export default function DetailsComment() {
-  //임시
-  const comments = [{ id: 1 }, { id: 2 }, { id: 3 }]
+import type { QnaComment } from '@/types'
+interface Props {
+  comments: QnaComment[]
+}
+export default function DetailsComment({ comments }: Props) {
   const [isOpen, setIsOpen] = useState(false)
   const [sortType, setSortType] = useState('최신순')
+
   return (
     <div>
       <div className="flex-center-between mt-[40px] mb-[20px]">
@@ -50,7 +52,7 @@ export default function DetailsComment() {
 
       <ul className="flex flex-col gap-[20px]">
         {comments.map((c) => (
-          <DetailsCommentItem key={c.id} />
+          <DetailsCommentItem comment={c} key={c.id} />
         ))}
       </ul>
     </div>

--- a/src/components/details/DetailsCommentItem.tsx
+++ b/src/components/details/DetailsCommentItem.tsx
@@ -1,14 +1,22 @@
-import ProfileImage from '@/assets/images/svg/ProfileThumb.svg'
-export default function DetailsCommentItem() {
+import ProfileImage from '@/components/common/ProfileImage'
+import type { QnaComment } from '@/types'
+interface Props {
+  comment: QnaComment
+}
+export default function DetailsCommentItem({ comment }: Props) {
   return (
     <li className="flex-start gap-[16px]">
-      <img src={ProfileImage} alt="프로필 이미지" />
+      <ProfileImage imageUrl={comment.author.profile_image_url} size={48} />
       <div className="w-full border-b border-[#E5E7EB] pb-[38px]">
         <div className="flex-center gap-[8px]">
-          <span className="font-semibold text-[#4d4d4d]">{'이름'}</span>
-          <span className="text-[12px] text-[#9d9d9d]">2025년 6월 13일</span>
+          <span className="font-semibold text-[#4d4d4d]">
+            {comment.author.nickname}
+          </span>
+          <span className="text-[12px] text-[#9d9d9d]">
+            {comment.created_at}
+          </span>
         </div>
-        <p className="mt-[20px]">도움 많이 되었습니다. 감사합니다!</p>
+        <p className="mt-[20px]">{comment.content}</p>
       </div>
     </li>
   )

--- a/src/components/details/DetailsContents.tsx
+++ b/src/components/details/DetailsContents.tsx
@@ -1,8 +1,11 @@
 import LinkShareIcon from '@/assets/images/svg/Link-share.svg?react'
-export default function DetailsContents() {
+interface Props {
+  content: string
+}
+export default function DetailsContents({ content }: Props) {
   return (
     <section className="details_content">
-      <div className="editor pb-[24px]">에디터내용이들어감</div>
+      <div className="editor pb-[24px]">{content}</div>
       <button type="button" className="icon_button ml-auto border">
         <LinkShareIcon />
         공유하기

--- a/src/components/details/DetailsHeader.tsx
+++ b/src/components/details/DetailsHeader.tsx
@@ -1,31 +1,41 @@
 import ChevronRightPupleIcon from '@/assets/images/svg/Chevron-right-puple.svg?react'
 import TitleQ from '@/assets/images/svg/TitleQ.svg?react'
 import ProfileImage from '@/assets/images/svg/ProfileThumb.svg'
-export default function DetailsHeader() {
+interface Props {
+  title: string
+  category: { names: string[] }
+  viewCount: number
+  created: string
+  name: string
+}
+export default function DetailsHeader({
+  title,
+  category,
+  viewCount,
+  created,
+  name,
+}: Props) {
   return (
     <section className="details_header">
       <div>
         <div className="details_header_breadcrumb">
-          프론트엔드 <ChevronRightPupleIcon /> 프로그래밍 언어{' '}
-          <ChevronRightPupleIcon /> Python
+          {category.names[0]} <ChevronRightPupleIcon /> {category.names[1]}
+          <ChevronRightPupleIcon /> {category.names[2]}
         </div>
 
         <h2 className="details_header_title">
           <TitleQ className="mt-[4px]" />
-          <span>
-            print 를 5번 쓰지않고, print 를 1번만 쓰고 5줄을 모두 표시 하는 법이
-            있나요?
-          </span>
+          <span>{title}</span>
         </h2>
         <div className="flex-center gap-[12px]">
-          <span className="text-[#9d9d9d]">조회수 60</span>
+          <span className="text-[#9d9d9d]">조회수 {viewCount}</span>
           <span className="dots"></span>
-          <span className="text-[#9d9d9d]">15 시간 전</span>
+          <span className="text-[#9d9d9d]">{created}</span>
         </div>
       </div>
       <div className="details_profile">
         <img src={ProfileImage} alt="프로필 이미지" />
-        <span className="details_profile_name">김태산</span>
+        <span className="details_profile_name">{name}</span>
       </div>
     </section>
   )

--- a/src/hooks/FetchQnaDetails.ts
+++ b/src/hooks/FetchQnaDetails.ts
@@ -1,6 +1,8 @@
-import type { QnaListResponse } from '@/types'
+import type { QnaDetailResponse } from '@/types'
 
-export const FetchQnaDetails = async (id: number): Promise<QnaListResponse> => {
+export const FetchQnaDetails = async (
+  id: number
+): Promise<QnaDetailResponse> => {
   const response = await fetch(`/api/qna/${id}`)
   if (!response.ok) {
     throw new Error('Failed to fetch QnA details')

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -81,7 +81,57 @@ export const handlers = [
         nickname: '한솔_회장',
         profile_image_url: null,
       },
-      answers: [],
+      answers: [
+        {
+          id: 501,
+          content:
+            'related_name을 지정하면 역참조 시 해당 이름으로 접근할 수 있습니다. 예를 들어 `post.comments.all()` 형태로 사용합니다.',
+          created_at: '2025-03-01 11:30:00',
+          is_adopted: true,
+          author: {
+            id: 102,
+            nickname: 'django_master',
+            profile_image_url:
+              'https://cdn.ozcodingschool.com/profile/user102.png',
+          },
+          comments: [
+            {
+              id: 1001,
+              content: '답변 감사합니다! 덕분에 이해됐어요.',
+              created_at: '2025-03-01 12:00:00',
+              author: {
+                id: 211,
+                nickname: '한솔_회장',
+                profile_image_url: null,
+              },
+            },
+            {
+              id: 1002,
+              content: '추가로 prefetch_related도 같이 쓰시면 좋아요.',
+              created_at: '2025-03-01 12:15:00',
+              author: {
+                id: 102,
+                nickname: 'django_master',
+                profile_image_url:
+                  'https://cdn.ozcodingschool.com/profile/user102.png',
+              },
+            },
+          ],
+        },
+        {
+          id: 502,
+          content:
+            'select_related와 prefetch_related 차이도 알아두시면 좋습니다.',
+          created_at: '2025-03-01 14:00:00',
+          is_adopted: false,
+          author: {
+            id: 305,
+            nickname: 'orm_lover',
+            profile_image_url: null,
+          },
+          comments: [],
+        },
+      ],
     }
 
     return HttpResponse.json(mockData)

--- a/src/pages/QnaDetailsPage.tsx
+++ b/src/pages/QnaDetailsPage.tsx
@@ -8,16 +8,25 @@ import { useParams } from 'react-router'
 export default function QnaDetailsPage() {
   const { id } = useParams<{ id: string }>()
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['qnaDetails'],
+    queryKey: ['qnaDetails', id],
     queryFn: () => FetchQnaDetails(Number(id)),
   })
+
+  if (isLoading) return <div>로딩</div>
+  if (isError || !data) return <div>에러</div>
   console.log(data)
   return (
     <div className="inner">
-      <DetailsHeader />
-      <DetailsContents />
+      <DetailsHeader
+        title={data.title}
+        category={data.category}
+        viewCount={data.view_count}
+        created={data.created_at}
+        name={data.author.nickname}
+      />
+      <DetailsContents content={data.content} />
       <DetailsWriter />
-      <DetailsAnswerList />
+      <DetailsAnswerList answers={data.answers} />
     </div>
   )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export interface QnaCategory {
 export interface QnaAuthor {
   id: number
   nickname: string
-  profile_image_url: string
+  profile_image_url: string | null
 }
 
 export interface QnaItem {
@@ -19,7 +19,7 @@ export interface QnaItem {
   answer_count: number
   view_count: number
   created_at: string
-  thumbnail_img_url: string
+  thumbnail_img_url: string | null
 }
 
 export interface QnaListResponse {
@@ -35,24 +35,26 @@ export interface QnaImage {
 export interface QnaAnswer {
   id: number
   content: string
-  author: QnaAuthor
   created_at: string
+  is_adopted: boolean
+  author: QnaAuthor
+  comments: QnaComment[]
+}
+export interface QnaComment {
+  id: number
+  content: string
+  created_at: string
+  author: QnaAuthor
 }
 export interface QnaDetailResponse {
   id: number
   title: string
   content: string
   category: QnaCategory
-  author: {
-    id: number
-    nickname: string
-    profile_image_url: string | null
-  }
-  images: QnaImage[] // mockData에 있는 이미지 리스트
+  author: QnaAuthor
+  images: QnaImage[]
   view_count: number
   created_at: string
   answers: QnaAnswer[]
-  // 썸네일은 리스트용일 경우가 많으나, 상세에서도 필요하다면 유지합니다.
-  // mockData에 맞추어 optional(?) 또는 null 허용 처리를 합니다.
   thumbnail_img_url?: string | null
 }


### PR DESCRIPTION
## 🚀 PR 요약

> 질의응답 상세페이지 목데이터로 변경

## ✏️ 변경 유형

- [ ] fix: 수정

## ✅ 체크리스트

- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 질의응답 상세페이지 목데이터로 변경추가

### 참고 사항


### 스크린 샷

## 🔗 연관된 이슈

> closes #37
