### PR TITLE
[feat] 답변 채택 ui 구현 (#43)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -130,6 +130,9 @@ body {
   .answer_box {
     @apply rounded-[20px] border border-[#cecece] p-[44px_38px];
   }
+  .answer_box.choice {
+    @apply relative border-2 border-[#6201e0] before:absolute before:-top-4 before:left-12 before:rounded-full before:bg-[#6210E0] before:px-3 before:py-1 before:text-[16px] before:text-white before:content-["질문자_채택"];
+  }
 
   .answer_name {
     @apply font-semibold text-[#4d4d4d];

--- a/src/components/details/DetailsAnswerItem.tsx
+++ b/src/components/details/DetailsAnswerItem.tsx
@@ -1,4 +1,4 @@
-import ProfileImage from '@/assets/images/svg/ProfileThumb.svg'
+import ProfileImage from '@/components/common/ProfileImage'
 import TextArea from '@/components/common/TextArea'
 import DetailsComment from '@/components/details/DetailsComment'
 import type { QnaAnswer } from '@/types'
@@ -7,11 +7,11 @@ interface Props {
 }
 export default function DetailsAnswerItem({ answer }: Props) {
   return (
-    <div className="answer_box">
+    <div className={`${answer.is_adopted ? 'choice' : ''} answer_box`}>
       {/* 답변 헤더 */}
       <div className="flex-center-between mb-[40px]">
         <div className="flex-center gap-[12px]">
-          <img src={ProfileImage} alt="프로필 이미지" />
+          <ProfileImage imageUrl={answer.author.profile_image_url} size={48} />
           <div>
             <span className="answer_name">{answer.author.nickname}</span>
             <p className="answer_info">


### PR DESCRIPTION
## 🚀 PR 요약

> 답변 채택 ui 구현

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가

## ✅ 체크리스트

- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 답변 채택 ui  추가

### 참고 사항


### 스크린 샷

<img width="727" height="353" alt="채택" src="https://github.com/user-attachments/assets/bf70d64b-ea80-49c5-a6c3-988b5e846ff5" />


## 🔗 연관된 이슈

> closes #43
