### PR TITLE
[feat] 질의응답 상세페이지 API 연동

### DIFF
--- a/src/api/qnadetails.ts
+++ b/src/api/qnadetails.ts
@@ -1,0 +1,13 @@
+import { api } from '@/api/api'
+import { BASE_URL } from '@/constants/qna'
+import type { QnaDetailResponse } from '@/types'
+
+export const QnaDetails = async (id: number): Promise<QnaDetailResponse> => {
+  // await new Promise((resolve) => setTimeout(resolve, 3000)) // 로딩 테스트 추후 삭제
+
+  const response = await api.get<QnaDetailResponse>(
+    `${BASE_URL}questions/${id}`
+  )
+
+  return response.data
+}

--- a/src/components/details/DetailsHeader.tsx
+++ b/src/components/details/DetailsHeader.tsx
@@ -20,10 +20,21 @@ export default function DetailsHeader({
 }: Props) {
   return (
     <section className="details_header">
-      <div>
+      <div className="flex-1">
         <div className="details_header_breadcrumb">
-          {category.names[0]} <ChevronRightPupleIcon /> {category.names[1]}
-          <ChevronRightPupleIcon /> {category.names[2]}
+          {category.names[0]}
+
+          {category.names[1] && (
+            <>
+              <ChevronRightPupleIcon /> {category.names[1]}
+            </>
+          )}
+
+          {category.names[2] && (
+            <>
+              <ChevronRightPupleIcon /> {category.names[2]}
+            </>
+          )}
         </div>
 
         <h2 className="details_header_title">

--- a/src/hooks/useQnaDetails.ts
+++ b/src/hooks/useQnaDetails.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query'
+import { QnaDetails } from '@/api/qnadetails'
+
+export function useQnaDetails(id: number) {
+  return useQuery({
+    queryKey: ['qnaDetails', id],
+    queryFn: () => QnaDetails(id),
+  })
+}

--- a/src/pages/QnaDetailsPage.tsx
+++ b/src/pages/QnaDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import DetailsHeader from '@/components/details/DetailsHeader'
 import DetailsContents from '@/components/details/DetailsContents'
 import DetailsWriter from '@/components/details/DetailsWriter'
@@ -6,7 +6,7 @@ import DetailsAnswerList from '@/components/details/DetailsAnswerList'
 import AiAnswerSection from '@/components/details/DetailsChatbot'
 import ProfileImage from '@/assets/images/svg/ProfileThumb.svg'
 import { useQuery } from '@tanstack/react-query'
-import { FetchQnaDetails } from '@/hooks/FetchQnaDetails'
+import { QnaDetails } from '@/api/qnadetails'
 import { useParams } from 'react-router'
 export default function QnaDetailsPage() {
   const { id } = useParams<{ id: string }>()
@@ -14,12 +14,20 @@ export default function QnaDetailsPage() {
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['qnaDetails', id],
-    queryFn: () => FetchQnaDetails(Number(id)),
+    queryFn: () => QnaDetails(Number(id)),
   })
+
+  // 페이지 마운트시 스크롤 탑으로 이동
+  useEffect(() => {
+    if (data) {
+      window.scrollTo(0, 0)
+    }
+  }, [data])
 
   if (isLoading) return <div>로딩</div>
   if (isError || !data) return <div>에러</div>
   console.log(data)
+
   return (
     <div className="inner">
       <DetailsHeader
@@ -36,7 +44,11 @@ export default function QnaDetailsPage() {
         <div className="mt-[52px]">
           <div className="flex items-center justify-between rounded-[20px] border border-[#E5E7EB] bg-white px-[38px] py-[24px]">
             <div className="flex items-center gap-[12px]">
-              <img src={ProfileImage} alt="프로필 이미지" className="h-[48px] w-[48px]" />
+              <img
+                src={ProfileImage}
+                alt="프로필 이미지"
+                className="h-[48px] w-[48px]"
+              />
               <div>
                 <span className="text-[12px] text-[#6201E0]">오즈오즈 님,</span>
                 <p className="text-[18px] font-semibold text-[#222]">


### PR DESCRIPTION
## 🚀 PR 요약

> 질의응답 상세페이지 API 연동

## ✏️ 변경 유형

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정
- [ ] style: 코드 포맷팅 등 스타일 변경
- [ ] refactor: 코드 리팩토링
- [ ] test: 테스트 코드 추가/수정
- [ ] chore: 기타 변경사항

## ✅ 체크리스트

- [ ] 커밋 컨벤션에 맞춰 커밋 메시지를 작성했습니다.
- [ ] 커밋에 관련된 이슈 번호를 포함했습니다.
- [ ] 실행에 문제가 없는지 테스트했습니다.

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 질의응답 상세페이지 API 연동

### 참고 사항

- 기존 목데이터 사용했던 FetchQnaDetails.ts 파일 삭제 해야함

### 스크린 샷


## 🔗 연관된 이슈

> closes #74
